### PR TITLE
Use MorganGenerator for Morgan fingerprints

### DIFF
--- a/tests/test_useful_rdkit_utils.py
+++ b/tests/test_useful_rdkit_utils.py
@@ -71,7 +71,7 @@ def test_mol2numpy_fp():
     fp_1 = uru.mol2numpy_fp(mol_1)
     mol_2 = Chem.MolFromSmiles("c1ccccc1")
     fp_2 = uru.mol2numpy_fp(mol_2)
-    assert fp_1.sum() == fp_2.sum()
+    np.testing.assert_array_equal(fp_1, fp_2)
 
 
 def test_rdkit_props_calc_mol():

--- a/useful_rdkit_utils/descriptors.py
+++ b/useful_rdkit_utils/descriptors.py
@@ -76,7 +76,8 @@ def mol2morgan_fp(mol: Mol, radius: int = 2, nBits: int = 2048) -> DataStructs.E
     :param nBits: number of fingerprint bits
     :return: RDKit Morgan fingerprint
     """
-    fp = AllChem.GetMorganFingerprintAsBitVect(mol, radius=radius, nBits=nBits)
+    mfpgen = rdFingerprintGenerator.GetMorganGenerator(radius=radius, fpSize=nBits)
+    fp = mfpgen.GetFingerprint(mol)
     return fp
 
 


### PR DESCRIPTION
## Description
Avoids usage of `GetMorganFingerprintAsBitVect` which produces deprecation warnings, which can be noisy. More details at https://greglandrum.github.io/rdkit-blog/posts/2023-01-18-fingerprint-generator-tutorial.html

## Status
- [ ] Ready to go